### PR TITLE
Fix to work with dokku-alt

### DIFF
--- a/pre-build
+++ b/pre-build
@@ -1,7 +1,15 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-APP="$1"; IMAGE="dokku/$APP"
+APP="$1";
+
+if ([[ -f "$(dirname $0)/../dokku_common" ]]); then
+  source "$(dirname $0)/../dokku_common"
+fi
+
+[ `declare -f -F check_app_name` ] && check_app_name "$APP" || IMAGE="dokku/$APP"
+
+
 APP_SPECIFIC_KEY_FOLDER="$DOKKU_ROOT/.deployment-keys/$APP/.ssh"
 SHARED_KEY_FOLDER="$DOKKU_ROOT/.deployment-keys/shared/.ssh"
 SOURCE_ENV_PATH="$HOME/$APP/ENV"


### PR DESCRIPTION
I tested deployment-keys and hostkeys plugins in a fresh installation of dokku-alt and I was able to deploy my application that uses private dependencies.