### PR TITLE
Add plugin.toml to silence failure messages on deploy

### DIFF
--- a/plugin.toml
+++ b/plugin.toml
@@ -1,0 +1,2 @@
+[plugin]
+description = "plugin for injecting hostkeys to the container"


### PR DESCRIPTION
When I deploy I get errors like the following:

```bash
$ g push production master
Total 0 (delta 0), reused 0 (delta 0)
remote: 2015/11/19 12:47:43 open /var/lib/dokku/plugins/available/deployment-keys/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:43 open /var/lib/dokku/plugins/available/deployment-keys/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:43 open /var/lib/dokku/plugins/available/hostkeys-plugin/plugin.toml: no such file or directory
-----> Cleaning up...
-----> Building app from herokuish...
-----> Adding BUILD_ENV to build environment...
remote: 2015/11/19 12:47:52 open /var/lib/dokku/plugins/available/deployment-keys/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:52 open /var/lib/dokku/plugins/available/hostkeys-plugin/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:53 open /var/lib/dokku/plugins/available/deployment-keys/plugin.toml: no such file or directory
remote: 2015/11/19 12:47:53 open /var/lib/dokku/plugins/available/hostkeys-plugin/plugin.toml: no such file or directory
```

So I added a `.toml` file to make it stop.