### PR TITLE
Simple fix to make deploymentkeys:delete work

### DIFF
--- a/commands
+++ b/commands
@@ -48,7 +48,7 @@ case "$1" in
   deploymentkeys:delete)
     check_app
     check_exists
-    rm -Rf "$APP_SPECIFIC_KEY_FOLDER/id_rsa*"
+    rm -Rf "$APP_SPECIFIC_KEY_FOLDER"/id_rsa*
     echo "Removed deployment keys for $APP"
     ;;
 


### PR DESCRIPTION
man bash:

Enclosing characters in double quotes preserves the literal value of all characters within the quotes, with the exception of $, `, \