### PR TITLE
Fix incompatibility with Dokku v0.32.3

### DIFF
--- a/pre-build
+++ b/pre-build
@@ -2,7 +2,7 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_ENABLED_PATH/common/functions"
 BUILDER_TYPE="$1" APP="$2"
-if [[ "$BUILDER_TYPE" != "herokuish" ]] then
+if [[ "$BUILDER_TYPE" != "herokuish" ]]; then
   exit 0
 fi
 IMAGE=$(get_app_image_name $APP)

--- a/pre-build
+++ b/pre-build
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 source "$PLUGIN_ENABLED_PATH/common/functions"
-APP="$1";
+BUILDER_TYPE="$1" APP="$2"
+if [[ "$BUILDER_TYPE" != "herokuish" ]] then
+  exit 0
+fi
 IMAGE=$(get_app_image_name $APP)
 
 APP_SPECIFIC_KEY_FOLDER="$DOKKU_ROOT/.deployment-keys/$APP/.ssh"

--- a/pre-build-buildpack
+++ b/pre-build-buildpack
@@ -1,1 +1,0 @@
-pre-build


### PR DESCRIPTION
When running dokku with `pre-build-buildpack` I'm getting this error. Using `pre-build` fixes the issue


```
-----> Cleaning up...
-----> Building app from herokuish
remote:  !     Deprecated: please upgrade plugin to use 'pre-build' plugin trigger instead of pre-build-buildpack
-----> Adding shared deployment-keys to build environment ...
-----> Adding host-keys to build environment ...
       Adding shared keys
-----> Adding BUILD_ENV to build environment...
       BUILD_ENV added successfully
-----> Adding shared deployment-keys to build environment ...
remote: Unable to find image 'dokku/herokuish:latest' locally
remote: docker: Error response from daemon: pull access denied for dokku/herokuish, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
remote: See 'docker run --help'.
remote:  !     Removing invalid image tag dokku/app:latest
remote:  !     App build failed
```